### PR TITLE
Fix a bug where the unreferenced files would still be in the manifest

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ module.exports = function RailsManifestPlugin(options) {
    */
   const __apply = (compiler) => {
     const outputName = this.__props.fileName;
-    const extraneous = this.__props.extraneous || {};
+    const initialExtraneous = this.__props.extraneous || {};
     const moduleAssets = {};
     const manifest = {};
 
@@ -67,6 +67,7 @@ module.exports = function RailsManifestPlugin(options) {
      * are done.
      */
     compiler.plugin('emit', (compilation, callback) => {
+      const extraneous = initialExtraneous;
       const stats = compilation.getStats().toJson();
 
        /**


### PR DESCRIPTION
Since the `extraneous` variable was set only in the `apply` method and reused afterwards, the unreferenced files wouldn't be removed until webpack was restarted. This is a potential problem when used with dev server or watch option.
