### PR TITLE
Use raw require path as the key for assets

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,21 @@ module.exports = function RailsManifestPlugin(options) {
     fse.outputFileSync(outputFile, manifest);
   };
 
+  const __findOriginalAsset = function(compilation, assetName) {
+    if (!compilation || !compilation.cache || typeof compilation.cache !== 'object') {
+      return null;
+    }
+
+    for (const cacheKey in compilation.cache) {
+      if (compilation.cache.hasOwnProperty(cacheKey)) {
+        const cache = compilation.cache[cacheKey];
+        if (cache.assets && assetName in cache.assets) {
+          return cache.rawRequest;
+        }
+      }
+    }
+    return null;
+  };
 
    /**
    * Webpack will call this method when installing the plugin. This registers
@@ -42,7 +57,7 @@ module.exports = function RailsManifestPlugin(options) {
    */
   const __apply = (compiler) => {
     const outputName = this.__props.fileName;
-    const extraneous = this.__props.extraneous || {};
+    const initialExtraneous = this.__props.extraneous || {};
     const moduleAssets = {};
     const manifest = {};
 
@@ -67,6 +82,7 @@ module.exports = function RailsManifestPlugin(options) {
      * are done.
      */
     compiler.plugin('emit', (compilation, callback) => {
+      const extraneous = initialExtraneous;
       const stats = compilation.getStats().toJson();
 
        /**
@@ -92,7 +108,9 @@ module.exports = function RailsManifestPlugin(options) {
        * module.
        */
       Object.assign(extraneous, stats.assets.reduce((acc, asset) => {
-        const assetName = moduleAssets[asset.name];
+        const originalAsset = __findOriginalAsset(compilation, asset.name);
+        const assetName = originalAsset || moduleAssets[asset.name];
+
         if (assetName) {
           acc[assetName] = asset.name;
         }


### PR DESCRIPTION
With this PR, the asset paths would depend on the original asset path instead of the output asset path.

Related issue: #3 

**Before**

``` JavaScript
{
   "assets/photo.jpg": "assets/44b3dae18da1232cf0c3c9aacd467ae6.jpg"
}
```

**After**

``` JavaScript
{
   "images/user/photo.jpg": "assets/44b3dae18da1232cf0c3c9aacd467ae6.jpg"
}
```
