### PR TITLE
Feature/custom asset paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,18 @@ You can specify a few options to the plugin:
 new RailsManifestPlugin({
   fileName: 'manifest.json', // Manifest file name to be written out
   writeToFileEmit: false, // Should we write to fs even if run with memory-fs
-  extraneous: null // Any assets specified as "extra"
+  extraneous: null, // Any assets specified as "extra"
+  mapAssetPath: (requirePath) => requirePath // Map the asset paths to the keys in manifest
 });
 ```
+
+### mapAssetPath
+
+The function will receive two arguments:
+* `requirePath` (e.g. `images/photos/sunset.jpg`) - the path that was originally required in JS/CSS/HTML
+* `outputPath` (e.g. `assets/sunset-44b3dae18da1232cf0c3c9aacd467ae6.jpg`) - the path where the file will be saved
+
+The function should return a string that will be used as a key in the manifest. By default, this will be the `requirePath` value.
 
 ## Rails
 

--- a/index.js
+++ b/index.js
@@ -31,6 +31,21 @@ module.exports = function RailsManifestPlugin(options) {
     fse.outputFileSync(outputFile, manifest);
   };
 
+  const __findOriginalAsset = function(compilation, assetName) {
+    if (!compilation || !compilation.cache || typeof compilation.cache !== 'object') {
+      return null;
+    }
+
+    for (const cacheKey in compilation.cache) {
+      if (compilation.cache.hasOwnProperty(cacheKey)) {
+        const cache = compilation.cache[cacheKey];
+        if (cache.assets && assetName in cache.assets) {
+          return cache.rawRequest;
+        }
+      }
+    }
+    return null;
+  };
 
    /**
    * Webpack will call this method when installing the plugin. This registers
@@ -42,7 +57,7 @@ module.exports = function RailsManifestPlugin(options) {
    */
   const __apply = (compiler) => {
     const outputName = this.__props.fileName;
-    const extraneous = this.__props.extraneous || {};
+    const initialExtraneous = this.__props.extraneous || {};
     const moduleAssets = {};
     const manifest = {};
 
@@ -67,6 +82,7 @@ module.exports = function RailsManifestPlugin(options) {
      * are done.
      */
     compiler.plugin('emit', (compilation, callback) => {
+      const extraneous = initialExtraneous;
       const stats = compilation.getStats().toJson();
 
        /**
@@ -92,7 +108,9 @@ module.exports = function RailsManifestPlugin(options) {
        * module.
        */
       Object.assign(extraneous, stats.assets.reduce((acc, asset) => {
-        const assetName = moduleAssets[asset.name];
+        const originalAsset = __findOriginalAsset(compilation, asset.name);
+        const assetName = originalAsset || moduleAssets[asset.name];
+
         if (assetName) {
           acc[assetName] = asset.name;
         }


### PR DESCRIPTION
This PR adds an optional `mapAssetPath` method which allows the user to manipulate the final asset key in manifest. The function receives two arguments, `requirePath` and `outputPath`. The function should return the key that should be used - by default, this will be the `requirePath` value.
