### PR TITLE
Renaming the plugin

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -16,8 +16,8 @@ configuration issue. Check the `example/` folder for a simple setup.
 ## Setup
 
 ```bash
-git clone https://github.com/infinum/webpack-rails-manifest-plugin
-cd webpack-rails-manifest-plugin
+git clone https://github.com/infinum/webpack-asset-pipeline
+cd webpack-asset-pipeline
 npm install
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-webpack-rails-manifest-plugin
+webpack-asset-pipeline
 ==============================
 
 A missing link for the asset pipeline alternative with Webpack.
 
-[![Build Status](https://semaphoreci.com/api/v1/infinum/webpack-rails-manifest-plugin/branches/master/shields_badge.svg)](https://semaphoreci.com/infinum/webpack-rails-manifest-plugin) [![npm version](https://badge.fury.io/js/webpack-rails-manifest-plugin.svg)](https://badge.fury.io/js/webpack-rails-manifest-plugin)
+[![Build Status](https://semaphoreci.com/api/v1/infinum/webpack-asset-pipeline/branches/master/shields_badge.svg)](https://semaphoreci.com/infinum/webpack-asset-pipeline) [![npm version](https://badge.fury.io/js/webpack-asset-pipeline.svg)](https://badge.fury.io/js/webpack-asset-pipeline)
 
 This plugin can be used to flush a list of your assets to a `manifest.json` file and replace the asset pipeline.
 
@@ -12,17 +12,17 @@ This plugin can be used to flush a list of your assets to a `manifest.json` file
 This is a Webpack plugin that creates a manifest file for your assets. It can output files to Webpack (as emitting) or as a file on the filesystem.
 
 ```
-npm install --save-dev webpack-rails-manifest-plugin
+npm install --save-dev webpack-asset-pipeline
 ```
 
 In your `webpack.config.js` file specify the plugin:
 
 ```JavaScript
-const RailsManifestPlugin = require('webpack-rails-manifest-plugin');
+const WebpackAssetPipeline = require('webpack-asset-pipeline');
 
 {
   plugins: [
-    new RailsManifestPlugin()
+    new WebpackAssetPipeline()
   ]
 }
 ```

--- a/documentation/integrations/rails.md
+++ b/documentation/integrations/rails.md
@@ -29,7 +29,7 @@ Now you can use it like this:
 <img src="#{webpack_asset_url('logo.svg')}" alt="logo" />
 ```
 
-to require your assets. [Here](https://github.com/infinum/webpack-rails-manifest-plugin/blob/master/example/webpack.config.js#L12) is an example of how to add a digest to a file.
+to require your assets. [Here](https://github.com/infinum/webpack-asset-pipeline/blob/master/example/webpack.config.js#L12) is an example of how to add a digest to a file.
 
 **Please note that you can't use Rails `image_tag`, `stylesheet_link_tag`, `javascript_include_tag` helpers.**
 

--- a/documentation/options.md
+++ b/documentation/options.md
@@ -4,7 +4,7 @@ Plugin options
 The plugin allows you to specify several options. Here are the default values:
 
 ```JavaScript
-new RailsManifestPlugin({
+new WebpackAssetPipeline({
   fileName: 'manifest.json',
   writeToFileEmit: false,
   extraneous: null,

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const path = require('path');
 const fse = require('fs-extra');
 
-module.exports = function RailsManifestPlugin(options) {
+module.exports = function WebpackAssetPipeline(options) {
 
    /**
    * Gets a file type from path.

--- a/index.test.js
+++ b/index.test.js
@@ -26,7 +26,7 @@ const runWebpack = function(callback, plugin, webpackConfig) {
   compiler.run(callback.bind(this));
 };
 
-describe('Webpack rails manifest plugin', () => {
+describe('webpack-asset-pipeline plugin', () => {
   it('can be required', () => {
     expect(Plugin).not.to.eq(undefined);
     expect(new Plugin().apply).not.to.eq(undefined);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "webpack-rails-manifest-plugin",
+  "name": "webpack-asset-pipeline",
   "version": "1.1.0",
   "description": "A missing link to Webpack and Rails integration",
   "main": "index.js",
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/infinum/webpack-rails-manifest-plugin.git"
+    "url": "git+https://github.com/infinum/webpack-asset-pipeline.git"
   },
   "keywords": [
     "rails",
@@ -39,9 +39,9 @@
     }
   ],
   "bugs": {
-    "url": "https://github.com/infinum/webpack-rails-manifest-plugin/issues"
+    "url": "https://github.com/infinum/webpack-asset-pipeline/issues"
   },
-  "homepage": "https://github.com/infinum/webpack-rails-manifest-plugin#readme",
+  "homepage": "https://github.com/infinum/webpack-asset-pipeline#readme",
   "devDependencies": {
     "babel-eslint": "^7.1.1",
     "chai": "^3.5.0",


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

**What is the current behavior?** (You can also link to an open issue here)

The name of the plugin is `webpack-rails-manifest-plugin`.

**What is the new behavior?**

After the rename the plugin name will be `webpack-asset-pipeline`.

**Does this PR introduce a breaking change?**
- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the following...

* Impact: The plugin will be renamed and will not be available on the NPM
* Migration path for existing applications: Replace the old library with the new one.
* Github Issue(s) this is regarding: #27 


**Other information**:

The tag line is not longer correct and needs to be updated. Opened for discussion here. The transition will be finished when #28 is completed. The release of `v1.2.0` is on hold until this is completed, and since this should break the `v2` version probably the milestone should be updated too.

In case we decide to use another name we can use this PR and it's diff as a base for the new name.

